### PR TITLE
Update main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
 
     int tileSize;
     const auto tileSizeChoices = {
-        64, 256, 400, 640
+        64, 128, 256, 400, 640
     };
     app.add_option("--tileSize", tileSize)
         ->description("Set the tile size")
@@ -99,6 +99,11 @@ int main(int argc, char *argv[]) {
     render->add_option("-o, --output", outputDirectory)
         ->description("Set the output directory")
         ->check(CLI::ExistingDirectory);
+
+    bool nosuffix = false;
+    render->add_flag("--nosuffix", nosuffix)
+        ->description("Set to not have the suffix added to the filenames")
+        ->default_val(nosuffix);
 
     double blend = 1.0/16.0;
     const auto blendChoices = {
@@ -235,7 +240,11 @@ int main(int argc, char *argv[]) {
             if (!outputDirectory.empty()) {
                 file = outputDirectory / file.filename();
             }
-            file.replace_filename(file.stem().string() + suffix);
+
+            if (!nosuffix) {                
+                file.replace_filename(file.stem().string() + suffix + file.extension().string());
+            }
+            
             if (frameCount == 1) {
                 file.replace_extension(".png");
                 writer.setFrameRate(1)


### PR DESCRIPTION
- Add 128 as tileSize option.
- Add option --nosuffix to skip filerenaming.

- Fix: Bug in the suffix renaming that didn't add extension back, causing issues with files that had a dot ( . ) in the filename, that would be cut off as part of the extension rename. For example; MyFile.001.jpg -> MyFile.001(denoise)(data) -> MyFile.png.